### PR TITLE
Load SSL certificate chain from PEM file

### DIFF
--- a/src/tcpsocketimpl.cpp
+++ b/src/tcpsocketimpl.cpp
@@ -262,32 +262,7 @@ void TcpSocketImpl::initSsl()
     if (_ssl)
         return;
 
-    {
-        MutexLock lock(_sslMutex);
-        if (!_sslCtx)
-        {
-            if (!_sslInitialized)
-            {
-                log_debug_to(ssl, "SSL_library_init");
-                SSL_library_init();
-
-                SslError::checkSslError();
-
-                thread_setup();
-
-                _sslInitialized = true;
-            }
-
-#ifdef HAVE_TLS_METHOD
-            log_debug_to(ssl, "SSL_CTX_new(TLS_method())");
-            _sslCtx = SSL_CTX_new(TLS_method());
-#else
-            log_debug_to(ssl, "SSL_CTX_new(SSLv23_method())");
-            _sslCtx = SSL_CTX_new(SSLv23_method());
-#endif
-            SslError::checkSslError();
-        }
-    }
+    initSslCtx();
 
     if (!_ssl)
     {
@@ -296,6 +271,37 @@ void TcpSocketImpl::initSsl()
 
         log_debug_to(ssl, "SSL_set_fd(" << _ssl << ", " << _fd << ')');
         SSL_set_fd(_ssl, _fd);
+    }
+}
+
+void TcpSocketImpl::initSslCtx()
+{
+    if (_sslCtx)
+        return;
+
+    MutexLock lock(_sslMutex);
+    if (!_sslCtx)
+    {
+        if (!_sslInitialized)
+        {
+            log_debug_to(ssl, "SSL_library_init");
+            SSL_library_init();
+
+            SslError::checkSslError();
+
+            thread_setup();
+
+            _sslInitialized = true;
+        }
+
+#ifdef HAVE_TLS_METHOD
+        log_debug_to(ssl, "SSL_CTX_new(TLS_method())");
+        _sslCtx = SSL_CTX_new(TLS_method());
+#else
+        log_debug_to(ssl, "SSL_CTX_new(SSLv23_method())");
+        _sslCtx = SSL_CTX_new(SSLv23_method());
+#endif
+        SslError::checkSslError();
     }
 }
 #endif // WITH_SSL

--- a/src/tcpsocketimpl.cpp
+++ b/src/tcpsocketimpl.cpp
@@ -1033,10 +1033,11 @@ bool TcpSocketImpl::_sslInitialized = false;
 void TcpSocketImpl::loadSslCertificateFile(const std::string& certFile, const std::string& privateKeyFile)
 {
     log_debug("load ssl certificate file \"" << certFile << '"');
-    initSsl();
-    int ret = SSL_use_certificate_file(_ssl, certFile.c_str(), SSL_FILETYPE_PEM);
+    initSslCtx();
+    int ret = SSL_CTX_use_certificate_chain_file(_sslCtx, certFile.c_str());
     if (ret != 1)
-        checkSslOperation(ret, "SSL_use_certificate_file", _pfd);
+        checkSslOperation(ret, "SSL_CTX_use_certificate_chain_file", _pfd);
+    initSsl();
 
     std::string key = privateKeyFile.empty() ? certFile : privateKeyFile;
     log_debug("load ssl private key file \"" << key << '"');

--- a/src/tcpsocketimpl.h
+++ b/src/tcpsocketimpl.h
@@ -129,6 +129,7 @@ class TcpSocketImpl : public IODeviceImpl
         void waitSslOperation(int ret, cxxtools::Timespan timeout);
 
         void initSsl();
+        void initSslCtx();
 #endif
 
     public:


### PR DESCRIPTION
The preferred function for loading certificates with the OpenSSL libraries is SSL_CTX_use_certificate_chain_file(), see NOTES section in [OpenSSL/docs](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_use_certificate_chain_file.html).

This function requires an SSL_CTX object.

cxxtools uses a specific SSL object that is created from an SSL_CTX object.
The Information is passed from the SSL_CTX object by copying.
Therefore, the SSL_CTX object must be initialized separately.
This can then be used to load the certificate chain.
After that the specific SSL object can be generated.

This Pull Request closes issue maekitalo/tntnet#59