### PR TITLE
fix -Wswitch: handle state_section0 and state_sectionsp

### DIFF
--- a/src/iniparser.cpp
+++ b/src/iniparser.cpp
@@ -363,7 +363,9 @@ void IniParser::end()
         case state_comment:
             break;
 
+        case state_section0:
         case state_section:
+        case state_sectionsp:
         case state_key:
         case state_key_sp:
         case state_valueesc:
@@ -394,7 +396,9 @@ const char* IniParser::expected() const
     switch (_state)
     {
         case state_0:           return "section start";
-        case state_section:     return "]";
+        case state_section0:    return "section name";
+        case state_section:
+        case state_sectionsp:   return "]";
         case state_key:         return "=";
         case state_key_sp:
         case state_value0:


### PR DESCRIPTION
The IniParser state enum has two states not handled in the end() and expected() switch statements, triggering -Wswitch. Add state_section0 to the error group in end() and return "section name" from expected(); add state_sectionsp to the error group in end() and fall through to state_section in expected() to return "]".