### PR TITLE
fix -Wunused-function: guard OpenSSL 1.x locking callbacks

### DIFF
--- a/src/sslctximpl.cpp
+++ b/src/sslctximpl.cpp
@@ -48,6 +48,7 @@ log_define("cxxtools.sslctx.impl")
 namespace cxxtools
 {
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static std::unique_ptr<std::mutex[]> openssl_mutex = nullptr;
 
 static unsigned long pthreads_thread_id()
@@ -60,6 +61,7 @@ static void pthreads_locking_callback(int mode, int n, const char* /* file */, i
     else
         openssl_mutex[n].unlock();
 }
+#endif
 
 SslCtx::Impl::Impl()
 {
@@ -71,10 +73,12 @@ SslCtx::Impl::Impl()
 
         SslError::checkSslError();
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         openssl_mutex.reset(new std::mutex[CRYPTO_num_locks()]);
 
         CRYPTO_set_id_callback(pthreads_thread_id);
         CRYPTO_set_locking_callback(pthreads_locking_callback);
+#endif
     });
 
 #ifdef HAVE_TLS_METHOD


### PR DESCRIPTION
CRYPTO_set_locking_callback and CRYPTO_set_id_callback are OpenSSL 1.x APIs for external thread-safety; in OpenSSL 1.1.0+ they are no-op macros and in OpenSSL 3.x+ they are removed entirely. Guard the two static callback functions and their registration with OPENSSL_VERSION_NUMBER < 0x10100000L so they are not compiled on modern OpenSSL where they are not needed.