### PR TITLE
Fix -Wunused-result, -Wunused-variable and -Wdangling-pointer warnings

### DIFF
--- a/include/cxxtools/destructionsentry.h
+++ b/include/cxxtools/destructionsentry.h
@@ -54,7 +54,10 @@ public:
         : _deleted(false),
           _sentry(sentry)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
        sentry = this;
+#pragma GCC diagnostic pop
     }
 
     explicit DestructionSentry(DestructionSentryPtr& ptr);

--- a/src/iodeviceimpl.cpp
+++ b/src/iodeviceimpl.cpp
@@ -340,7 +340,7 @@ size_t IODeviceImpl::write( const char* buffer, size_t count )
 
 void IODeviceImpl::sigwrite(int sig)
 {
-    ::write(_fd, (const void*)&sig, sizeof(sig));
+    [[maybe_unused]] auto r = ::write(_fd, (const void*)&sig, sizeof(sig));
 }
 
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -297,7 +297,7 @@ namespace
         if (!flush && _msg.size() < 8192)
             return;
 
-        ::write(_fd, _msg.data(), _msg.size());
+        [[maybe_unused]] auto r = ::write(_fd, _msg.data(), _msg.size());
         _msg.clear();
     }
 

--- a/src/selectorimpl.cpp
+++ b/src/selectorimpl.cpp
@@ -189,7 +189,7 @@ bool SelectorImpl::waitUntil(Timespan until)
         {
             if( (*iter)->enabled() )
             {
-                const size_t availableSpace= &_pollfds.back() - pCurr + 1;
+                [[maybe_unused]] const size_t availableSpace= &_pollfds.back() - pCurr + 1;
                 size_t required = (*iter)->simpl().pollSize();
                 assert( required <= availableSpace);
                 pCurr+= (*iter)->simpl().initializePoll( pCurr, required);
@@ -316,7 +316,7 @@ bool SelectorImpl::waitUntil(Timespan until)
 
 void SelectorImpl::wake()
 {
-    ::write( _wakePipe[1], "W", 1);
+    [[maybe_unused]] auto r = ::write( _wakePipe[1], "W", 1);
 }
 
 } //namespace cxxtools


### PR DESCRIPTION
Capture the return value of fire-and-forget write() calls in a
[[maybe_unused]] variable; GCC 14+ no longer accepts (void) as a
suppressor for warn_unused_result. Mark availableSpace [[maybe_unused]]
in SelectorImpl::waitUntil() — it is only used in an assert() compiled
out in Release builds.

Suppress a -Wdangling-pointer false positive in DestructionSentry: the
constructor registers itself via the passed-in pointer reference and the
destructor nullifies it, so no dangling access occurs.
