### PR TITLE
time: fix usec left uninitialized in operator>>= when microsecond fie…

### DIFF
--- a/src/time.cpp
+++ b/src/time.cpp
@@ -360,7 +360,7 @@ void operator >>=(const SerializationInfo& si, Time& time)
             || (p = si.findMember("usec")) != 0)
             *p >>= usec;
         else
-            msec = 0;
+            usec = 0;
 
         time.set(hour, min, sec, msec, usec);
     }


### PR DESCRIPTION
…ld absent

Fixes: 
```
[91/189] Building CXX object src/CMakeFiles/cxxtools.dir/time.cpp.o In file included from ../src/time.cpp:30:
In member function 'void cxxtools::Time::set(unsigned int, unsigned int, unsigned int, unsigned int, unsigned int)',
    inlined from 'void cxxtools::operator>>=(const SerializationInfo&, Time&)' at ../src/time.cpp:365:17:
../include/cxxtools/time.h:177:105: warning: 'usec' may be used uninitialized [-Wmaybe-uninitialized]
  177 |             _usecs = (((((static_cast<uint64_t>(hour) * 60 + min) * 60) + sec) * 1000) + msec) * 1000 + usec;
      |                                                                                                         ^~~~
../src/time.cpp: In function 'void cxxtools::operator>>=(const SerializationInfo&, Time&)':
../src/time.cpp:337:46: note: 'usec' was declared here
  337 |         unsigned short hour, min, sec, msec, usec;
      |                                              ^~~~
``` 