### PR TITLE
cmake: add install rules for sub-libraries

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -14,3 +14,8 @@ add_library(cxxtools-bin
 )
 
 target_link_libraries(cxxtools-bin cxxtools)
+
+install(TARGETS cxxtools-bin
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -19,3 +19,8 @@ add_library(cxxtools-http
 )
 
 target_link_libraries(cxxtools-http cxxtools)
+
+install(TARGETS cxxtools-http
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/src/json/CMakeLists.txt
+++ b/src/json/CMakeLists.txt
@@ -14,3 +14,8 @@ add_library(cxxtools-json
 )
 
 target_link_libraries(cxxtools-json cxxtools cxxtools-http)
+
+install(TARGETS cxxtools-json
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/src/unit/CMakeLists.txt
+++ b/src/unit/CMakeLists.txt
@@ -11,3 +11,8 @@ add_library(cxxtools-unit
 )
 
 target_link_libraries(cxxtools-unit cxxtools)
+
+install(TARGETS cxxtools-unit
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/src/xmlrpc/CMakeLists.txt
+++ b/src/xmlrpc/CMakeLists.txt
@@ -10,3 +10,8 @@ add_library(cxxtools-xmlrpc
 )
 
 target_link_libraries(cxxtools-xmlrpc cxxtools cxxtools cxxtools-http)
+
+install(TARGETS cxxtools-xmlrpc
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)


### PR DESCRIPTION
The cmake build defines cxxtools-http, cxxtools-json, cxxtools-bin, cxxtools-xmlrpc and cxxtools-unit but provides no install() rules for them; only the main cxxtools library is installed.  Add LIBRARY and ARCHIVE install destinations for each sub-library to match the autotools build.